### PR TITLE
Fix location of version file

### DIFF
--- a/bundles/org.opensmarthouse.core/src/main/java/org/opensmarthouse/core/OpenSmartHouse.java
+++ b/bundles/org.opensmarthouse.core/src/main/java/org/opensmarthouse/core/OpenSmartHouse.java
@@ -75,7 +75,7 @@ public class OpenSmartHouse {
      */
     public static String buildString() {
         Properties prop = new Properties();
-        Path versionFilePath = Paths.get(getUserDataFolder(), "etc", "version.properties");
+        Path versionFilePath = Paths.get("etc", "version.properties");
         try (FileInputStream fis = new FileInputStream(versionFilePath.toFile())) {
             prop.load(fis);
             String buildNo = prop.getProperty("build-no");


### PR DESCRIPTION
In OSH the `etc` folder is not in the `userdata` folder.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>