### PR TITLE
Provide 'compat' features which bridge oh and osh features.

### DIFF
--- a/features/karaf/compat.xsl
+++ b/features/karaf/compat.xsl
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright (c) 2019-2020 Contributors to the OpenSmartHouse project
+
+    See the NOTICE file(s) distributed with this work for additional
+    information.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:features="http://karaf.apache.org/xmlns/features/v1.4.0" exclude-result-prefixes="features">
+
+  <!--
+  This basic transformation set allows to generate "compat" feature set which allows to run standard
+  OH bindings with OSH. Entire thing is generating "openhab-xyz" feature which refer source feature
+  "opensmarthouse-xyz".
+  -->
+  <xsl:output method="xml" encoding="utf-8" indent="yes" />
+
+  <xsl:template match="/">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="features:features/@name">
+    <xsl:attribute name="name">
+      <xsl:value-of select="concat(., '-compat')" />
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="features:feature">
+    <xsl:element name="feature" namespace="{namespace-uri()}">
+      <xsl:attribute name="name">
+        <xsl:call-template name="string-replace-all">
+          <xsl:with-param name="text" select="attribute::name"/>
+          <xsl:with-param name="replace" select="'opensmarthouse-'"/>
+          <xsl:with-param name="by" select="'openhab-'"/>
+        </xsl:call-template>
+      </xsl:attribute>
+      <xsl:element name="feature" namespace="{namespace-uri()}">
+        <xsl:value-of select="@name" />
+      </xsl:element>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- string-replace-all from http://geekswithblogs.net/Erik/archive/2008/04/01/120915.aspx -->
+  <xsl:template name="string-replace-all">
+    <xsl:param name="text" />
+    <xsl:param name="replace" />
+    <xsl:param name="by" />
+    <xsl:choose>
+      <xsl:when test="contains($text, $replace)">
+        <xsl:value-of select="substring-before($text,$replace)" />
+        <xsl:value-of select="$by" />
+        <xsl:call-template name="string-replace-all">
+          <xsl:with-param name="text"
+            select="substring-after($text,$replace)" />
+          <xsl:with-param name="replace" select="$replace" />
+          <xsl:with-param name="by" select="$by" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$text" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/features/karaf/opensmarthouse-core/pom.xml
+++ b/features/karaf/opensmarthouse-core/pom.xml
@@ -42,17 +42,62 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/feature/feature-compat.xml</file>
+                  <type>xml</type>
+                  <classifier>compat</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
         <version>${karaf.tooling.version}</version>
-
-          <executions>
-            <execution>
-              <id>verify</id>
-              <phase>none</phase>
-            </execution>
-          </executions>
-
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0.2</version>
+        <configuration>
+          <transformationSets>
+            <transformationSet>
+              <dir>${project.build.directory}/feature/</dir>
+              <outputDir>${project.build.directory}/feature/</outputDir>
+              <stylesheet>${project.basedir}/../compat.xsl</stylesheet>
+              <includes>
+                <include>feature.xml</include>
+              </includes>
+              <fileMappers>
+                <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                  <pattern>feature.xml</pattern>
+                  <replacement>feature-compat.xml</replacement>
+                </fileMapper>
+              </fileMappers>
+            </transformationSet>
+          </transformationSets>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>transform</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/features/karaf/opensmarthouse-tp/pom.xml
+++ b/features/karaf/opensmarthouse-tp/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -16,9 +16,62 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/feature/feature-compat.xml</file>
+                  <type>xml</type>
+                  <classifier>compat</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
         <version>${karaf.tooling.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0.2</version>
+        <configuration>
+          <transformationSets>
+            <transformationSet>
+              <dir>${project.build.directory}/feature/</dir>
+              <outputDir>${project.build.directory}/feature/</outputDir>
+              <stylesheet>${project.basedir}/../compat.xsl</stylesheet>
+              <includes>
+                <include>feature.xml</include>
+              </includes>
+              <fileMappers>
+                <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                  <pattern>feature.xml</pattern>
+                  <replacement>feature-compat.xml</replacement>
+                </fileMapper>
+              </fileMappers>
+            </transformationSet>
+          </transformationSets>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>transform</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Given that we need to provide a way to run openHAB bindings within OSH I come with idea of "compat" feature sets. These features are really "shells" over OSH features within same name. For example `opensmarthouse-tp-jax-rs` will become `openhab-tp-jax-rs` in compat layer refering "source" feature. To make it visual:
```
    <feature name="openhab-tp-jackson">
        <feature>opensmarthouse-tp-jackson</feature>
    </feature>
        
    <feature name="openhab-tp-jax-rs">
        <feature>opensmarthouse-tp-jax-rs</feature>
    </feature>
        
    <feature name="openhab-tp-jax-rs-whiteboard">
        <feature>opensmarthouse-tp-jax-rs-whiteboard</feature>
    </feature>
```

Given that we have a bit more features in core than openHAB we should be able to bridge all necessary elements in semi automatic way.

For now compat features do not specify any versions cause we have conflict between 0.9 and 3.0. Transformation can be updated to include both, but for simplicity I omitted them.