### PR TITLE
Fix ADR typo and rename adr_log.md to readme.md

### DIFF
--- a/adr/readme.md
+++ b/adr/readme.md
@@ -9,9 +9,9 @@ An ADR is to be produced for all proposed significant architectural changes to _
 | [ADR0000](adr0000.md) | 01MAY2020 | ACCEPTED  | Separation of API and implementation packages             |
 | [ADR0001](adr0001.md) | 16MAY2020 | ACCEPTED  | Introduce Type Provider                                   |
 | [ADR0002](adr0002.md) | 18MAY2020 | PROPOSED  | Thing Provisioning Framework                              |
-| [ADE0003](adr0003.md) | 26MAY2020 | ACCEPTED  | Type System Refactoring                                   |
-| [ADE0004](adr0004.md) | 26MAY2020 | PROPOSED  | Provide Discovery Index                                   |
-| [ADE0005](adr0005.md) | 28MAY2020 | ACCEPTED  | Differentiate thing handler and device configuration      |
-| [ADE0006](adr0006.md) | 07JUN2020 | PROPOSED  | Add Command and State Attributes                          |
-| [ADE0007](adr0007.md) | 22JUN2020 | ACCEPTED  | Add ThingType versioning                                  |
-| [ADE0008](adr0008.md) | 07JUN2020 | PROPOSED  | Add binding events concept                                |
+| [ADR0003](adr0003.md) | 26MAY2020 | ACCEPTED  | Type System Refactoring                                   |
+| [ADR0004](adr0004.md) | 26MAY2020 | PROPOSED  | Provide Discovery Index                                   |
+| [ADR0005](adr0005.md) | 28MAY2020 | ACCEPTED  | Differentiate thing handler and device configuration      |
+| [ADR0006](adr0006.md) | 07JUN2020 | PROPOSED  | Add Command and State Attributes                          |
+| [ADR0007](adr0007.md) | 22JUN2020 | ACCEPTED  | Add ThingType versioning                                  |
+| [ADR0008](adr0008.md) | 07JUN2020 | PROPOSED  | Add binding events concept                                |


### PR DESCRIPTION
Signed-off-by: Chris Jackson <chris@cd-jackson.com>