### PR TITLE
[karaf] Tune up openhab compatibility features.

### DIFF
--- a/features/karaf/opensmarthouse-core/src/main/feature/feature.xml
+++ b/features/karaf/opensmarthouse-core/src/main/feature/feature.xml
@@ -13,7 +13,7 @@
     SPDX-License-Identifier: EPL-2.0
 
 -->
-<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 
     <repository>mvn:org.opensmarthouse.core.features.karaf/org.opensmarthouse.core.features.karaf.opensmarthouse-tp/${project.version}/xml/features</repository>
 
@@ -96,10 +96,6 @@
         <bundle>mvn:org.opensmarthouse.core.bundles/org.opensmarthouse.core.io.rest.core/${project.version}</bundle>
         <bundle>mvn:org.opensmarthouse.core.bundles/org.opensmarthouse.core.io.rest.sse/${project.version}</bundle>
         -->
-    </feature>
-
-    <feature name="openhab-core-base">
-        <feature>opensmarthouse-core-base</feature>
     </feature>
 
     <feature name="opensmarthouse-core-transform" description="Open SmartHouse Core: Transform" version="${project.version}">
@@ -860,10 +856,6 @@
 
         <feature>opensmarthouse-runtime-karaf</feature>
         <feature>opensmarthouse-core-io-rest-core</feature>
-    </feature>
-
-    <feature name="openhab-runtime-base">
-        <feature>opensmarthouse-runtime-base</feature>
     </feature>
 
     <feature name="opensmarthouse-core" version="${project.version}">


### PR DESCRIPTION
Fix for #12.
The 'openhab-runtime-base' and 'openhab-core-base' features are evicted from opensmarthouse feature set.
In order to stick with these a complete 'compat' feature set must be used.

A side effect of this change is change of core feature karaf namespace to 1.4.0.
This is necessary to make XSLT transformation work.

The downgraded (1.3.0) version of namespace was introduced to temporary disable validation of requirements/capabilities which caused troubles.
Given that most of features is stable and we strip req/cap from manifest now we can re-enable validation.

Signed-off-by: Łukasz Dywicki <luke@code-house.org>