### PR TITLE
Remove OSH_RUNTIME / openhab.runtime variables as they are not used

### DIFF
--- a/features/karaf/framework/src/main/resources/resources/bin/oh2_dir_layout
+++ b/features/karaf/framework/src/main/resources/resources/bin/oh2_dir_layout
@@ -11,10 +11,6 @@ if [ -z ${OSH_CONF} ]; then
     export OSH_CONF="${OSH_HOME}/config"
 fi
 
-if [ -z ${OSH_RUNTIME} ]; then
-    export OSH_RUNTIME="${OSH_HOME}/data"
-fi
-
 if [ -z ${OSH_USERDATA} ]; then
     export OSH_USERDATA="${OSH_HOME}/data"
 fi

--- a/features/karaf/framework/src/main/resources/resources/bin/setenv
+++ b/features/karaf/framework/src/main/resources/resources/bin/setenv
@@ -93,7 +93,6 @@ fi
 export JAVA_OPTS="${JAVA_OPTS}
   -Dopenhab.home=${OSH_HOME}
   -Dopenhab.conf=${OSH_CONF}
-  -Dopenhab.runtime=${OSH_RUNTIME}
   -Dopenhab.userdata=${OSH_USERDATA}
   -Dopenhab.logdir=${OSH_LOGDIR}
   -Djava.library.path=${OSH_USERDATA}/tmp/lib


### PR DESCRIPTION
This removes the `OSH_RUNTIME` environment variable, and the subsequent setting of the `openhab.runtime` property as this is not used in OSH, and also appears not to be used in openHAB. It is therefore removed to avoid confusion around what it does.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>